### PR TITLE
Add Markdown Component Loader as prior art

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -331,6 +331,7 @@ These projects define the syntax which MDX blends together (MD and JSX).
 ### Libraries
 
 - [MDXC](https://github.com/jamesknelson/mdxc)
+- [Markdown Component Loader](https://github.com/ticky/markdown-component-loader)
 - [markdown-in-js](https://github.com/threepointone/markdown-in-js)
 - [remark-jsx](https://github.com/fazouane-marouane/remark-jsx)
 - [remark-react](https://github.com/mapbox/remark-react)


### PR DESCRIPTION
[Markdown Component Loader](https://github.com/ticky/markdown-component-loader) was built in mid-2017 (months prior to the proposal which kicked off the mdx standard), and implements almost the same feature set as the current mdx standard (it even coined the `mdx` extension), albeit with different syntax!