### PR TITLE
Add reference to Literate Programming

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -377,6 +377,7 @@ These projects define the syntax which MDX blends together (MD and JSX).
 
 - [IA Markdown Content Blocks](https://github.com/iainc/Markdown-Content-Blocks)
 - [Idyll: Markup language for interactive documents](https://idyll-lang.org)
+- [Literate Programming](https://en.wikipedia.org/wiki/Literate_programming)
 - [Literate CoffeeScript](https://coffeescript.org/#literate)
 
 ### Is your work missing?

--- a/readme.md
+++ b/readme.md
@@ -377,6 +377,7 @@ These projects define the syntax which MDX blends together (MD and JSX).
 
 - [IA Markdown Content Blocks](https://github.com/iainc/Markdown-Content-Blocks)
 - [Idyll: Markup language for interactive documents](https://idyll-lang.org)
+- [Literate CoffeeScript](https://coffeescript.org/#literate)
 
 ### Is your work missing?
 


### PR DESCRIPTION
This looks like a direct implementation of [Literate Programming](https://en.wikipedia.org/wiki/Literate_programming) for JSX. However, I don't see any reference to Literate Programming in the readme or any of the related discussions around this.

(I don't necessarily think this PR should be merged as is. But I _would_ like to see a reference to Literate Programming somewhere in the readme, as this concept has a much longer pedigree.)
